### PR TITLE
Add test script and clean ebpf warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ Terminal 3 (view statistics):
 
 ## Testing
 
-Run the automated test suite:
+Run the automated test suite using the helper script. This script builds the
+project, sets up a temporary test interface, runs a quick Interest/Data
+exchange, and prints the resulting statistics:
 
 ```bash
 ./test_udcn.sh

--- a/test_udcn.sh
+++ b/test_udcn.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+
+IFACE=${1:-udcn0}
+IP=10.0.100.1
+INTERVAL=2
+
+cleanup() {
+    echo "Cleaning up" >&2
+    sudo ip link del "$IFACE" 2>/dev/null || true
+    if [ -n "${DAEMON_PID:-}" ]; then sudo kill "$DAEMON_PID" 2>/dev/null || true; fi
+    if [ -n "${SERVER_PID:-}" ]; then kill "$SERVER_PID" 2>/dev/null || true; fi
+}
+trap cleanup EXIT
+
+echo "Building µDCN..."
+cargo build --release
+
+echo "Setting up dummy interface $IFACE"
+sudo ip link add name "$IFACE" type dummy 2>/dev/null || true
+sudo ip link set "$IFACE" up
+sudo ip addr add "$IP/24" dev "$IFACE" 2>/dev/null || true
+
+echo "Starting XDP daemon..."
+sudo ./target/release/udcn --iface "$IFACE" run --stats-interval "$INTERVAL" &
+DAEMON_PID=$!
+sleep 2
+
+echo "Starting data server..."
+./target/release/udcn serve -n "/test/data" -c "Hello from µDCN" -b "$IP:6363" &
+SERVER_PID=$!
+sleep 1
+
+echo "Sending interest packet"
+./target/release/udcn send -n "/test/data" -t "$IP:6363"
+
+sleep "$((INTERVAL+1))"
+
+echo "\nCollected statistics:"
+sudo ./target/release/udcn stats

--- a/udcn-ebpf/src/main.rs
+++ b/udcn-ebpf/src/main.rs
@@ -191,7 +191,7 @@ fn handle_interest(interest: udcn_common::InterestPacket) -> Result<u32, u32> {
         timestamp: 0,
     };
 
-    if let Err(_) = unsafe { PIT.insert(&name_hash, &pit_entry, 0) } {
+    if let Err(_) = PIT.insert(&name_hash, &pit_entry, 0) {
         update_stats(|stats| stats.drops += 1);
         return Ok(xdp_action::XDP_DROP);
     }
@@ -202,10 +202,10 @@ fn handle_interest(interest: udcn_common::InterestPacket) -> Result<u32, u32> {
 fn handle_data(data_pkt: udcn_common::DataPacket, _full_packet: &[u8]) -> Result<u32, u32> {
     let name_hash = data_pkt.name_hash;
     
-    if let Some(_pit_entry) = unsafe { PIT.get(&name_hash) } {
+    if let Some(_pit_entry) = PIT.get(&name_hash) {
         update_stats(|stats| stats.pit_hits += 1);
         
-        let _ = unsafe { PIT.remove(&name_hash) };
+        let _ = PIT.remove(&name_hash);
 
         let cache_entry = CacheEntry {
             name_hash,
@@ -213,7 +213,7 @@ fn handle_data(data_pkt: udcn_common::DataPacket, _full_packet: &[u8]) -> Result
             timestamp: 0,
         };
 
-        let _ = unsafe { CONTENT_STORE.insert(&name_hash, &cache_entry, 0) };
+        let _ = CONTENT_STORE.insert(&name_hash, &cache_entry, 0);
 
         // For now, skip actual data caching to avoid verifier issues
         // In a real implementation, we'd copy packet data here


### PR DESCRIPTION
## Summary
- provide `test_udcn.sh` to exercise the µDCN eBPF/XDP network
- fix unused unsafe blocks in eBPF code
- document the new helper script in the README

## Testing
- `cargo test -p udcn-common --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686488bdead083218d23042670b65434